### PR TITLE
Fix urls for Django>=4.0

### DIFF
--- a/polls/urls.py
+++ b/polls/urls.py
@@ -1,7 +1,11 @@
 #-*- coding: utf-8 -*-
-from django.conf.urls import url
+try:
+    from django.conf.urls import url
+except:
+    from django.urls import re_path as url
 
 from . import views
+
 
 app_name = "polls"
 urlpatterns = [


### PR DESCRIPTION
I'm following the [django-cms tuto](https://docs.django-cms.org/en/latest/introduction/03-integrating_applications.html) and had to fix that for me... could be usefull for others?